### PR TITLE
Fix DD/MM/YYYY HH:MM date format

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -71,7 +71,11 @@ function validateTime(value) {
  * @returns {string}
  */
 function formatDatetime(value) {
-    const date = dayjs(value, "D/M H:m");
+    let date = dayjs(value, "D/M/Y H:m");
+
+    if (!date.isValid()) {
+        date = dayjs(value, "D/M H:m");
+    }
 
     return date.format("DD/MM/YYYY HH:mm");
 }


### PR DESCRIPTION
`formatDatetime` had unexpected behavior when given `DD/MM/YYYY HH:MM` instead of `DD/MM HH:MM`. This PR fixes this behavior and correctly handles both formats as expected.

Example:
```js
console.log(formatDatetime("22/04 16:00"));
console.log(formatDatetime("22/04/2025 16:00"));
```

Current output (prior to this PR):
```
22/04/2025 16:00
22/04/2025 20:05
```

Expected output (working as expected on this PR):
```
22/04/2025 16:00
22/04/2025 16:00
```